### PR TITLE
Remove setuptools-scm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,10 @@ setup(
     description='backend service for JSON and binary data storage',
     author='Mantas Zimnickas',
     author_email='sirexas@gmail.com',
+    version='0.0.1',
     licence='AGPL',
     packages=['qvarn'],
-    setup_requires=['setuptools_scm'],
     install_requires=read_requirements('requirements.in'),
-    use_scm_version=True,
     entry_points={
         'console_scripts': [
             'qvarn = qvarn.app:main',


### PR DESCRIPTION
`setuptool-scm` causes problems when building without git repository.

I suggest removing it for now and updating version manually until these problems are resolved.